### PR TITLE
Add Spring Boot backend and Angular frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # saas-ia-2
+
+This repository contains a simple Java Spring Boot backend and an Angular frontend.
+
+## Prerequisites
+- Java 21 and Gradle
+- Node.js 20+ and npm
+- Angular CLI (`npm install -g @angular/cli`) for local development
+
+## Backend
+The backend project lives in the `backend/` directory.
+
+Run the application:
+```bash
+cd backend
+./gradlew bootRun
+```
+The service starts on `http://localhost:8080` and exposes a sample API at `GET /api/data`.
+
+## Frontend
+The Angular project is in `frontend/`.
+
+Install dependencies and start the dev server:
+```bash
+cd frontend
+npm install
+npm start
+```
+During development, API calls to `/api` are proxied to the backend thanks to `proxy.conf.json`.
+
+## Integration
+When both servers are running, open `http://localhost:4200` in your browser. The home page loads data from the Spring Boot backend and displays it in a list.

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '21'
+
+defaultTasks 'bootRun'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+bootRun {
+    args = []
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'backend'

--- a/backend/src/main/java/com/example/demo/BackendApplication.java
+++ b/backend/src/main/java/com/example/demo/BackendApplication.java
@@ -1,0 +1,11 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/demo/SampleController.java
+++ b/backend/src/main/java/com/example/demo/SampleController.java
@@ -1,0 +1,21 @@
+package com.example.demo;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class SampleController {
+
+    @GetMapping("/data")
+    public Map<String, Object> getData() {
+        return Map.of(
+                "message", "Hello from Spring Boot",
+                "items", List.of("item1", "item2", "item3")
+        );
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/backend/src/test/java/com/example/demo/BackendApplicationTests.java
+++ b/backend/src/test/java/com/example/demo/BackendApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "defaultProject": "frontend",
+  "projects": {
+    "frontend": {
+      "projectType": "application",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "options": {
+            "outputPath": "dist",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "tsConfig": "tsconfig.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "options": {
+            "browserTarget": "frontend:build",
+            "proxyConfig": "proxy.conf.json"
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ng serve --proxy-config proxy.conf.json",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "rxjs": "^7.8.0",
+    "tslib": "^2.6.0",
+    "zone.js": "^0.14.2"
+  },
+  "devDependencies": {
+    "@angular/cli": "^17.3.0",
+    "@angular/compiler-cli": "^17.3.0",
+    "typescript": "~5.3.3"
+  }
+}

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false
+  }
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,4 @@
+<h1>{{ data?.message }}</h1>
+<ul>
+  <li *ngFor="let item of data?.items">{{ item }}</li>
+</ul>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent implements OnInit {
+  data: any;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit(): void {
+    this.http.get('/api/data').subscribe(res => this.data = res);
+  }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,11 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, HttpClientModule],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Frontend</title>
+  <base href="/">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { enableProdMode } from '@angular/core';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 2rem; }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es2017",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
+  }
+}


### PR DESCRIPTION
## Summary
- initialize `backend` with a minimal Spring Boot project
- add a simple REST controller returning sample data
- scaffold `frontend` Angular project with a component fetching API data
- configure dev proxy for API calls
- document how to run both apps in README

## Testing
- `gradle wrapper` *(fails: plugin resolution requires network)*
- `npm install` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685e9711fc10832c8d6a52b82844ac5a